### PR TITLE
Github Actions Discord PR Notification

### DIFF
--- a/.github/workflows/pr-to-discord.yml
+++ b/.github/workflows/pr-to-discord.yml
@@ -1,0 +1,24 @@
+name: Notify Discord on PR
+
+on:
+  pull_request:
+    types: [opened]
+  branches:
+      - main
+      - develop
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send PR to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{\"content\": \"📣 New Pull Request by **$PR_AUTHOR**: [$PR_TITLE]($PR_URL)\"}" \
+               $DISCORD_WEBHOOK_URL


### PR DESCRIPTION
Added a workflow for github to send a message on one of our channels whenever someone makes a PR into main or develop