### PR TITLE
Form review filter method

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/FormRequestsController.java
+++ b/backend/src/main/java/com/example/demo/controller/FormRequestsController.java
@@ -1,6 +1,7 @@
 package com.example.demo.controller;
 
 import com.example.demo.exceptions.InvalidHeaderException;
+import com.example.demo.model.enums.FormRequestStatus;
 import com.example.demo.response.FormRequestResponse;
 import com.example.demo.exceptions.FormRequestFieldDataException;
 import com.example.demo.exceptions.InvalidFormRequestIdException;
@@ -41,6 +42,22 @@ public class FormRequestsController {
             return ResponseEntity.badRequest().build();
         }
     }
+
+    @GetMapping("/review-requests")
+    public ResponseEntity<List<FormRequestResponse>> getAllFormsForReview(@RequestHeader("Authorization") String authorizationHeader) {
+        // Logic to retrieve all pending forms
+        try{
+            if (!authorizationHeader.startsWith("Bearer ")) {
+                throw new InvalidHeaderException("No authorization header containing Bearer was received");
+            }
+            return ResponseEntity.ok(formRequestService.getFormRequestsByStatus(FormRequestStatus.PENDING));
+        }
+        catch (InvalidHeaderException e){
+            this.logger.error(e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
 
     @GetMapping("/{id}")
     public ResponseEntity<FormRequest> getFormRequestById(@PathVariable Long id) {

--- a/backend/src/main/java/com/example/demo/repository/FormRequestRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/FormRequestRepository.java
@@ -1,6 +1,7 @@
 package com.example.demo.repository;
 
 import com.example.demo.entity.FormRequest;
+import com.example.demo.model.enums.FormRequestStatus;
 import com.example.demo.projection.FormRequestFieldsProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,6 +10,7 @@ import java.util.Optional;
 
 public interface FormRequestRepository extends JpaRepository<FormRequest, Long> {
     List<FormRequest> findByUserRegistrationNumber(String userRegistrationNumber);
+    List<FormRequest> findByStatus(FormRequestStatus status);
     FormRequestFieldsProjection findFormRequestFieldsById(Long id);
     Optional<FormRequest> findById(long id);
 }

--- a/backend/src/main/java/com/example/demo/service/FormRequestService.java
+++ b/backend/src/main/java/com/example/demo/service/FormRequestService.java
@@ -73,6 +73,18 @@ public class FormRequestService {
         return formRequestsResponse;
     }
 
+    //Used to get requests based on status
+    //Can also be used to filter requests by status (for students combined with user filtering)
+    public List<FormRequestResponse> getFormRequestsByStatus(FormRequestStatus status) {
+        List<FormRequest> formRequests = formRequestRepository.findByStatus(status);
+
+        List<FormRequestResponse> formRequestsResponse = new ArrayList<>();
+        for (FormRequest formRequest : formRequests) {
+            String formTitle = formRepository.findTitleById(formRequest.getFormId()).getTitle();
+            formRequestsResponse.add(new FormRequestResponse(formRequest.getId(), formTitle, formRequest.getStatus()));
+        }
+        return formRequestsResponse;
+    }
     public void approveRequest(long requestId) {
         // secretary page
     }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve form requests based on their status, specifically adding functionality to fetch pending review requests. It includes updates to the controller, service, and repository layers, as well as the necessary model imports.

### Controller Enhancements:
* Added a new endpoint `getAllFormsForReview` in `FormRequestsController` to retrieve form requests with a `PENDING` status. It validates the `Authorization` header and handles exceptions for invalid headers.

### Service Layer Updates:
* Introduced a new method `getFormRequestsByStatus` in `FormRequestService` to fetch form requests by their status and map them to `FormRequestResponse` objects.

### Repository Enhancements:
* Added a new method `findByStatus` in `FormRequestRepository` to query form requests by their status.

### Model Import Updates:
* Imported the `FormRequestStatus` enum in both `FormRequestsController` and `FormRequestRepository` to support the new functionality. [[1]](diffhunk://#diff-c70dd7d9ffac060e34bc1f0eb8e7307925d7776520e0394bc56af753f7e74e8fR4) [[2]](diffhunk://#diff-35f66162d9dd319c5af74a7d0735a214802942ba000b7d3b12e7cf1442fa5f06R4)